### PR TITLE
Feature/hashtag 01

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -232,3 +232,4 @@ gradle-app.setting
 ### Custom ###
 db_dev.mv.db
 db_dev.trace.db
+/src/test/resources/application.yml

--- a/backend/src/main/java/com/example/backend/content/hashtag/exception/HashtagErrorCode.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/exception/HashtagErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.backend.content.hashtag.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.backend.global.error.ErrorCodeIfs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum HashtagErrorCode implements ErrorCodeIfs {
+
+	INVALID_HASHTAG_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태그 특수문자를 포함할 수 없습니다."),
+	EMPTY_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태크 내용이 없습니다."),
+	TOO_LONG_HASHTAG_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태그 길이가 10자를 초과합니다."),
+	NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 데이터를 찾을 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final Integer code;
+	private final String description;
+}

--- a/backend/src/main/java/com/example/backend/content/hashtag/exception/HashtagErrorCode.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/exception/HashtagErrorCode.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 public enum HashtagErrorCode implements ErrorCodeIfs {
 
 	INVALID_HASHTAG_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태그 특수문자를 포함할 수 없습니다."),
-	EMPTY_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태크 내용이 없습니다."),
+	EMPTY_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태그 내용이 없습니다."),
 	TOO_LONG_HASHTAG_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태그 길이가 10자를 초과합니다."),
 	NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 데이터를 찾을 수 없습니다.");
 

--- a/backend/src/main/java/com/example/backend/content/hashtag/exception/HashtagException.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/exception/HashtagException.java
@@ -1,0 +1,39 @@
+package com.example.backend.content.hashtag.exception;
+
+import com.example.backend.global.error.ErrorCodeIfs;
+import com.example.backend.global.exception.BackendExceptionIfs;
+
+import lombok.Getter;
+
+@Getter
+public class HashtagException extends RuntimeException implements BackendExceptionIfs {
+
+	private final ErrorCodeIfs errorCodeIfs;
+	private final String errorDescription;
+
+	public HashtagException(ErrorCodeIfs errorCodeIfs) {
+		super(errorCodeIfs.getDescription());
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorCodeIfs.getDescription();
+
+	}
+
+	public HashtagException(ErrorCodeIfs errorCodeIfs, String errorDescription) {
+		super(errorCodeIfs.getDescription());
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorDescription;
+	}
+
+	public HashtagException(ErrorCodeIfs errorCodeIfs, Throwable tx) {
+		super(tx);
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorCodeIfs.getDescription();
+	}
+
+	public HashtagException(ErrorCodeIfs errorCodeIfs, Throwable tx, String errorDescription) {
+		super(tx);
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorDescription;
+	}
+
+}

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagExtractor.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagExtractor.java
@@ -1,0 +1,25 @@
+package com.example.backend.content.hashtag.service;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class HashtagExtractor {
+
+	private static final Pattern HASHTAG_EXTRACT_PATTERN = Pattern.compile("#([\\w가-힣]+)");
+
+	public Set<String> extractHashtag(String content) {
+		Set<String> hashtags = new LinkedHashSet<>();
+		Matcher matcher = HASHTAG_EXTRACT_PATTERN.matcher(content);
+
+		while (matcher.find()) {
+			hashtags.add(matcher.group(1));
+		}
+
+		return hashtags;
+	}
+}

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagExtractor.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagExtractor.java
@@ -6,7 +6,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Component;
-
+/**
+ * #으로 시작되는 해시태그를 추출할 수 있는 클래스
+ * @author kwak
+ * @since 2025-02-03
+ */
 @Component
 public class HashtagExtractor {
 

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
@@ -1,0 +1,37 @@
+package com.example.backend.content.hashtag.service;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+
+import com.example.backend.content.hashtag.exception.HashtagErrorCode;
+import com.example.backend.content.hashtag.exception.HashtagException;
+import com.example.backend.entity.HashtagEntity;
+import com.example.backend.entity.HashtagRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HashtagService {
+
+	private final HashtagRepository hashtagRepository;
+
+	public HashtagEntity createIfNotExists(String content) {
+		return hashtagRepository.findByContent(content)
+			.orElseGet(() -> hashtagRepository.save(
+				HashtagEntity.builder()
+					.content(content)
+					.build()
+			));
+	}
+
+	public HashtagEntity findByContent(String content) {
+		return hashtagRepository.findByContent(content)
+			.orElseThrow(() -> new HashtagException(HashtagErrorCode.NOT_FOUND));
+	}
+
+}

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
@@ -13,7 +13,10 @@ import com.example.backend.entity.HashtagEntity;
 import com.example.backend.entity.HashtagRepository;
 
 import lombok.RequiredArgsConstructor;
-
+/**
+ * @author kwak
+ * @since 2025-02-03
+ */
 @Service
 @RequiredArgsConstructor
 public class HashtagService {

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
@@ -12,7 +12,11 @@ import com.example.backend.entity.PostHashtagEntity;
 import com.example.backend.entity.PostHashtagRepository;
 
 import lombok.RequiredArgsConstructor;
-
+/**
+ * hashtag 와 post 의 연결 담당하는 클래스
+ * @author kwak
+ * @since 2025-02-03
+ */
 @Service
 @RequiredArgsConstructor
 public class PostHashtagService {

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
@@ -1,0 +1,40 @@
+package com.example.backend.content.hashtag.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.example.backend.entity.HashtagEntity;
+import com.example.backend.entity.PostEntity;
+import com.example.backend.entity.PostHashtagEntity;
+import com.example.backend.entity.PostHashtagRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostHashtagService {
+
+	private final HashtagService hashtagService;
+	private final PostHashtagRepository postHashtagRepository;
+
+	public List<PostHashtagEntity> create(PostEntity post, Set<String> contents) {
+		List<HashtagEntity> hashtags = contents.stream()
+			.map(hashtagService::createIfNotExists)
+			.collect(Collectors.toList());
+
+		List<PostHashtagEntity> postHashtags = hashtags.stream()
+			.map(hashtag ->
+				PostHashtagEntity.builder()
+					.post(post)
+					.hashtag(hashtag)
+					.build()
+			).collect(Collectors.toList());
+
+		return postHashtagRepository.saveAll(postHashtags);
+
+	}
+
+}

--- a/backend/src/main/java/com/example/backend/entity/HashtagEntity.java
+++ b/backend/src/main/java/com/example/backend/entity/HashtagEntity.java
@@ -1,5 +1,10 @@
 package com.example.backend.entity;
 
+import java.util.regex.Pattern;
+
+import com.example.backend.content.hashtag.exception.HashtagErrorCode;
+import com.example.backend.content.hashtag.exception.HashtagException;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -19,10 +24,32 @@ import lombok.NoArgsConstructor;
 @Builder
 @Table(name = "hashtag")
 public class HashtagEntity {
+
+	private static final Pattern HASHTAG_PATTERN = Pattern.compile("^[\\w가-힣]+$");
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@Column(unique = true, nullable = false)
 	private String content;
+
+	public HashtagEntity(String content) {
+		validateContent(content);
+		this.content = content;
+	}
+
+	private void validateContent(String content) {
+
+		if (content == null || content.isBlank()) {
+			throw new HashtagException(HashtagErrorCode.EMPTY_CONTENT);
+		}
+		if (content.length() > 10) {
+			throw new HashtagException(HashtagErrorCode.TOO_LONG_HASHTAG_CONTENT);
+		}
+		if (!HASHTAG_PATTERN.matcher(content).matches()) {
+			throw new HashtagException(HashtagErrorCode.INVALID_HASHTAG_CONTENT);
+		}
+
+	}
 }

--- a/backend/src/main/java/com/example/backend/entity/HashtagEntity.java
+++ b/backend/src/main/java/com/example/backend/entity/HashtagEntity.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
+
 @Table(name = "hashtag")
 public class HashtagEntity {
 
@@ -34,6 +34,7 @@ public class HashtagEntity {
 	@Column(unique = true, nullable = false)
 	private String content;
 
+	@Builder
 	public HashtagEntity(String content) {
 		validateContent(content);
 		this.content = content;

--- a/backend/src/main/java/com/example/backend/entity/HashtagRepository.java
+++ b/backend/src/main/java/com/example/backend/entity/HashtagRepository.java
@@ -1,6 +1,11 @@
 package com.example.backend.entity;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HashtagRepository extends JpaRepository<HashtagEntity, Long> {
+
+	Optional<HashtagEntity> findByContent(String content);
+
 }

--- a/backend/src/test/java/com/example/backend/content/hashtag/service/HashtagExtractorTest.java
+++ b/backend/src/test/java/com/example/backend/content/hashtag/service/HashtagExtractorTest.java
@@ -1,0 +1,32 @@
+package com.example.backend.content.hashtag.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class HashtagExtractorTest {
+
+	@Autowired
+	HashtagExtractor hashtagExtractor;
+
+	@Test
+	void extractHashtag() {
+
+		String content = "#고양이 #강아지#고양이#개구리 너무너무 귀여워";
+
+		Set<String> result = hashtagExtractor.extractHashtag(content);
+
+		assertThat(result.size()).isEqualTo(3);
+		assertThat(result).contains("고양이");
+		assertThat(result).contains("강아지");
+		assertThat(result).contains("개구리");
+
+	}
+}

--- a/backend/src/test/java/com/example/backend/content/hashtag/service/HashtagServiceTest.java
+++ b/backend/src/test/java/com/example/backend/content/hashtag/service/HashtagServiceTest.java
@@ -1,0 +1,48 @@
+package com.example.backend.content.hashtag.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.backend.entity.HashtagEntity;
+import com.example.backend.entity.HashtagRepository;
+
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+	@Mock
+	private HashtagRepository hashtagRepository;
+
+	@InjectMocks
+	private HashtagService hashtagService;
+
+	@Test
+	@DisplayName("db에 존재하면 저장이 되지 않아야 함")
+	void createIfNotExists() {
+
+		// given
+		String content = "고양이";
+		HashtagEntity existingHashtag = HashtagEntity.builder()
+			.content(content)
+			.build();
+		when(hashtagRepository.findByContent(content)).thenReturn(Optional.of(existingHashtag));
+
+		// when
+		HashtagEntity result = hashtagService.createIfNotExists(content);
+
+		// then
+		assertNotNull(result);
+		assertEquals("고양이", result.getContent());
+		verify(hashtagRepository, times(0)).save(any(HashtagEntity.class));
+
+	}
+
+}

--- a/backend/src/test/java/com/example/backend/content/hashtag/service/PostHashtagServiceTest.java
+++ b/backend/src/test/java/com/example/backend/content/hashtag/service/PostHashtagServiceTest.java
@@ -1,0 +1,62 @@
+package com.example.backend.content.hashtag.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.backend.entity.MemberEntity;
+import com.example.backend.entity.MemberRepository;
+import com.example.backend.entity.PostEntity;
+import com.example.backend.entity.PostHashtagEntity;
+import com.example.backend.entity.PostHashtagRepository;
+import com.example.backend.entity.PostRepository;
+
+@SpringBootTest
+@Transactional
+class PostHashtagServiceTest {
+
+	@Autowired
+	PostHashtagService postHashtagService;
+	@Autowired
+	HashtagService hashtagService;
+	@Autowired
+	PostHashtagRepository postHashtagRepository;
+	@Autowired
+	PostRepository postRepository;
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("create 통합 테스트")
+	void create() {
+
+		MemberEntity member = memberRepository.save(MemberEntity.builder()
+			.username("testUser")
+			.email("testuser@example.com")
+			.password("password123")
+			.build());
+
+		PostEntity post = postRepository.save(
+			PostEntity.builder()
+				.content("#고양이 짱짱귀엽네요")
+				.member(member)
+				.build());
+
+		Set<String> contents = Set.of("고양이", "강아지");
+
+		List<PostHashtagEntity> postHashtagEntities = postHashtagService.create(post, contents);
+		assertThat(postHashtagEntities.size()).isEqualTo(2);
+		assertThat(postHashtagEntities.get(0).getHashtag().getContent()).isEqualTo("고양이");
+		assertThat(postHashtagEntities.get(1).getHashtag().getContent()).isEqualTo("강아지");
+
+	}
+}


### PR DESCRIPTION
## 📌 과제 설명
---
post 의 content 로 부터 해시태그를 추출하여 등록하는 기능을 구현

## 👩‍💻 요구 사항과 구현 내용
---
- [x] 해시태그 추출을 담당하는 클래스는 다른 곳에서도 필요할 수 있으니 별도의 클래스로 구분
- [x] 해시태그 엔티티에 대한 유효성 검증 로직 구현 
  - 해시태그는 글자수는 10자를 초과할 수 없다
  - 해시태그는 영어,숫자,한글,_ 만 허용된다
- [x] post 서비스에서 등록 시점에 content 를 가져와서 해시태그 추출과 해시태그 생성을 진행
- [x] 만약 해시태그가 이미 존재하면 저장하지 않고 가져오기만 실행

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

close #8 