### PR TITLE
Feature/hashtag 02 해시태그 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/BackendApplication.java
+++ b/backend/src/main/java/com/example/backend/BackendApplication.java
@@ -3,8 +3,10 @@ package com.example.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/example/backend/content/hashtag/scheduler/HashtagScheduler.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/scheduler/HashtagScheduler.java
@@ -1,4 +1,4 @@
-package com.example.backend.global.scheduler;
+package com.example.backend.content.hashtag.scheduler;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
@@ -1,10 +1,5 @@
 package com.example.backend.content.hashtag.service;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.springframework.stereotype.Service;
 
 import com.example.backend.content.hashtag.exception.HashtagErrorCode;
@@ -22,14 +17,17 @@ import lombok.RequiredArgsConstructor;
 public class HashtagService {
 
 	private final HashtagRepository hashtagRepository;
+	private final HashtagUsageCollector collector;
 
 	public HashtagEntity createIfNotExists(String content) {
-		return hashtagRepository.findByContent(content)
+		HashtagEntity hashtag = hashtagRepository.findByContent(content)
 			.orElseGet(() -> hashtagRepository.save(
 				HashtagEntity.builder()
 					.content(content)
 					.build()
 			));
+		collector.addUsageStorage(hashtag.getId());
+		return hashtag;
 	}
 
 	public HashtagEntity findByContent(String content) {

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
 import com.example.backend.content.hashtag.exception.HashtagErrorCode;
@@ -21,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class HashtagService {
+
+	private static final long OLD_HASHTAG_MONTH = 3;
 
 	private final HashtagRepository hashtagRepository;
 	private final HashtagUsageCollector collector;
@@ -46,7 +47,8 @@ public class HashtagService {
 	}
 
 	public List<Long> findOldHashtags() {
-		return hashtagRepository.findOldHashtags(LocalDateTime.now().minusMonths(3));
+		return hashtagRepository.findOldHashtags(LocalDateTime.now()
+			.minusMonths(OLD_HASHTAG_MONTH));
 	}
 
 	public void bulkLastUsedAt(Set<Long> hashtagUsageData, LocalDateTime now) {

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
@@ -1,5 +1,8 @@
 package com.example.backend.content.hashtag.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.example.backend.content.hashtag.exception.HashtagErrorCode;
@@ -8,6 +11,7 @@ import com.example.backend.entity.HashtagEntity;
 import com.example.backend.entity.HashtagRepository;
 
 import lombok.RequiredArgsConstructor;
+
 /**
  * @author kwak
  * @since 2025-02-03
@@ -35,4 +39,11 @@ public class HashtagService {
 			.orElseThrow(() -> new HashtagException(HashtagErrorCode.NOT_FOUND));
 	}
 
+	public void deleteOldHashtag(List<Long> oldHashtagIds) {
+		hashtagRepository.bulkDeleteByIds(oldHashtagIds);
+	}
+
+	public List<Long> findOldHashtags() {
+		return hashtagRepository.findOldHashtags(LocalDateTime.now().minusMonths(3));
+	}
 }

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagService.java
@@ -2,7 +2,9 @@ package com.example.backend.content.hashtag.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
 import com.example.backend.content.hashtag.exception.HashtagErrorCode;
@@ -45,5 +47,9 @@ public class HashtagService {
 
 	public List<Long> findOldHashtags() {
 		return hashtagRepository.findOldHashtags(LocalDateTime.now().minusMonths(3));
+	}
+
+	public void bulkLastUsedAt(Set<Long> hashtagUsageData, LocalDateTime now) {
+		hashtagRepository.bulkLastUsedAt(hashtagUsageData, now);
 	}
 }

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagUsageCollector.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagUsageCollector.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 /**
  * 사용된 hashtag 의 데이터를 수집하고 처리
  * @author kwak
- * 2025/02/03
+ * @since 2025-02-03
  */
 @Component
 public class HashtagUsageCollector {

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagUsageCollector.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/HashtagUsageCollector.java
@@ -1,0 +1,29 @@
+package com.example.backend.content.hashtag.service;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * 사용된 hashtag 의 데이터를 수집하고 처리
+ * @author kwak
+ * 2025/02/03
+ */
+@Component
+public class HashtagUsageCollector {
+
+	private final Set<Long> usageStorage = ConcurrentHashMap.newKeySet();
+
+	public void addUsageStorage(Long hashtagId) {
+		usageStorage.add(hashtagId);
+	}
+
+	public Set<Long> flushUsageStorage() {
+		Set<Long> copy = new HashSet<>(usageStorage);
+		usageStorage.clear();
+		return copy;
+	}
+
+}

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
@@ -12,6 +12,7 @@ import com.example.backend.entity.PostHashtagEntity;
 import com.example.backend.entity.PostHashtagRepository;
 
 import lombok.RequiredArgsConstructor;
+
 /**
  * hashtag 와 post 의 연결 담당하는 클래스
  * @author kwak
@@ -40,7 +41,8 @@ public class PostHashtagService {
 		return postHashtagRepository.saveAll(postHashtags);
 
 	}
-	//todo posthashtag delete 로직
 
-
+	public void deleteByHashtagIds(List<Long> oldHashtagIds) {
+		postHashtagRepository.bulkDeleteByHashtagIds(oldHashtagIds);
+	}
 }

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
@@ -52,6 +52,6 @@ public class PostHashtagService {
 	 * @since 2025-02-04
 	 */
 	public void deleteByPostId(Long postId) {
-		postHashtagRepository.deleteByPostId();
+		postHashtagRepository.deleteByPostId(postId);
 	}
 }

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
@@ -40,5 +40,7 @@ public class PostHashtagService {
 		return postHashtagRepository.saveAll(postHashtags);
 
 	}
+	//todo posthashtag delete 로직
+
 
 }

--- a/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
@@ -45,4 +45,13 @@ public class PostHashtagService {
 	public void deleteByHashtagIds(List<Long> oldHashtagIds) {
 		postHashtagRepository.bulkDeleteByHashtagIds(oldHashtagIds);
 	}
+
+	/**
+	 * post 삭제시 연관된 postHashtag 를 삭제하는 기능
+	 * @author kwak
+	 * @since 2025-02-04
+	 */
+	public void deleteByPostId(Long postId) {
+		postHashtagRepository.deleteByPostId();
+	}
 }

--- a/backend/src/main/java/com/example/backend/entity/HashtagEntity.java
+++ b/backend/src/main/java/com/example/backend/entity/HashtagEntity.java
@@ -1,5 +1,6 @@
 package com.example.backend.entity;
 
+import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 
 import com.example.backend.content.hashtag.exception.HashtagErrorCode;
@@ -21,7 +22,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-
 @Table(name = "hashtag")
 public class HashtagEntity {
 
@@ -34,10 +34,17 @@ public class HashtagEntity {
 	@Column(unique = true, nullable = false)
 	private String content;
 
+	@Column(nullable = false)
+	private LocalDateTime lastUsedAt;
+
+	@Column(nullable = false)
+	private boolean isDeleted;
+
 	@Builder
 	public HashtagEntity(String content) {
 		validateContent(content);
 		this.content = content;
+		this.lastUsedAt = LocalDateTime.now();
 	}
 
 	private void validateContent(String content) {

--- a/backend/src/main/java/com/example/backend/entity/HashtagRepository.java
+++ b/backend/src/main/java/com/example/backend/entity/HashtagRepository.java
@@ -1,6 +1,7 @@
 package com.example.backend.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -18,11 +19,28 @@ public interface HashtagRepository extends JpaRepository<HashtagEntity, Long> {
 	 * @author kwak
 	 * @since 2025-02-03
 	 */
-	@Modifying
+	@Modifying(clearAutomatically = true)
 	@Query("""
 		UPDATE HashtagEntity h
 		SET h.lastUsedAt = :now
 		WHERE h.id IN :hashtagUsageData
 		""")
 	void bulkLastUsedAt(@Param("hashtagUsageData") Set<Long> hashtagUsageData, @Param("now") LocalDateTime now);
+
+	/**
+	 * ids 기반으로 벌크성 삭제 쿼리
+	 * @author kwak
+	 * @since 2025-02-03
+	 */
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM HashtagEntity h WHERE h.id IN :ids")
+	int bulkDeleteByIds(@Param("ids") List<Long> ids);
+
+	/**
+	 * 사용한지 3개월 이상 된 hashtag Id 조회
+	 * @author kwak
+	 * @since 2025-02-03
+	 */
+	@Query("SELECT h.id FROM HashtagEntity h WHERE h.lastUsedAt < :date")
+	List<Long> findOldHashtags(@Param("targetDate") LocalDateTime targetDate);
 }

--- a/backend/src/main/java/com/example/backend/entity/HashtagRepository.java
+++ b/backend/src/main/java/com/example/backend/entity/HashtagRepository.java
@@ -1,11 +1,28 @@
 package com.example.backend.entity;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HashtagRepository extends JpaRepository<HashtagEntity, Long> {
 
 	Optional<HashtagEntity> findByContent(String content);
 
+	/**
+	 * hashtag 의 lastUsedAt 을 현재시간으로 한번에 업데이트 하는 벌크성 쿼리입니다
+	 * @author kwak
+	 * @since 2025-02-03
+	 */
+	@Modifying
+	@Query("""
+		UPDATE HashtagEntity h
+		SET h.lastUsedAt = :now
+		WHERE h.id IN :hashtagUsageData
+		""")
+	void bulkLastUsedAt(@Param("hashtagUsageData") Set<Long> hashtagUsageData, @Param("now") LocalDateTime now);
 }

--- a/backend/src/main/java/com/example/backend/entity/PostHashtagEntity.java
+++ b/backend/src/main/java/com/example/backend/entity/PostHashtagEntity.java
@@ -34,7 +34,4 @@ public class PostHashtagEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	HashtagEntity hashtag;
 
-	@Column(nullable = false)
-	private boolean isDeleted;
-
 }

--- a/backend/src/main/java/com/example/backend/entity/PostHashtagEntity.java
+++ b/backend/src/main/java/com/example/backend/entity/PostHashtagEntity.java
@@ -1,5 +1,6 @@
 package com.example.backend.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -32,4 +33,8 @@ public class PostHashtagEntity {
 	@JoinColumn(nullable = false, name = "hashtag_id")
 	@ManyToOne(fetch = FetchType.LAZY)
 	HashtagEntity hashtag;
+
+	@Column(nullable = false)
+	private boolean isDeleted;
+
 }

--- a/backend/src/main/java/com/example/backend/entity/PostHashtagRepository.java
+++ b/backend/src/main/java/com/example/backend/entity/PostHashtagRepository.java
@@ -1,6 +1,25 @@
 package com.example.backend.entity;
 
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostHashtagRepository extends JpaRepository<PostHashtagEntity, Long> {
+
+	/**
+	 * hashtagIds 를 기반으로 postHashtag 일괄 삭제
+	 * 추후에 데이터 양 너무 커지면 배치처리 필요
+	 * @author kwak
+	 * @since 2025-02-03
+	 */
+	@Modifying(clearAutomatically = true)
+	@Query("""
+		DELETE FROM PostHashtagEntity ph
+		WHERE ph.hashtag.id IN :hashtagIds
+		""")
+	void bulkDeleteByHashtagIds(@Param("hashtagIds") List<Long> hashtagIds);
 }

--- a/backend/src/main/java/com/example/backend/entity/PostHashtagRepository.java
+++ b/backend/src/main/java/com/example/backend/entity/PostHashtagRepository.java
@@ -22,4 +22,7 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtagEntity, 
 		WHERE ph.hashtag.id IN :hashtagIds
 		""")
 	void bulkDeleteByHashtagIds(@Param("hashtagIds") List<Long> hashtagIds);
+
+	@Query("DELETE FROM PostHashtagEntity ph WHERE ph.post.id = :postId")
+	void deleteByPostId(@Param("postId") Long postId);
 }

--- a/backend/src/main/java/com/example/backend/global/scheduler/HashtagScheduler.java
+++ b/backend/src/main/java/com/example/backend/global/scheduler/HashtagScheduler.java
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 public class HashtagScheduler {
 
 	private final HashtagUsageCollector hashtagUsageCollector;
-	private final HashtagRepository hashtagRepository;
 	private final PostHashtagService postHashtagService;
 	private final HashtagService hashtagService;
 
@@ -44,7 +43,7 @@ public class HashtagScheduler {
 			log.info("Not Exist hashtag Usage Data");
 			return;
 		}
-		hashtagRepository.bulkLastUsedAt(hashtagUsageData, LocalDateTime.now());
+		hashtagService.bulkLastUsedAt(hashtagUsageData, LocalDateTime.now());
 	}
 
 	/**

--- a/backend/src/main/java/com/example/backend/global/scheduler/HashtagScheduler.java
+++ b/backend/src/main/java/com/example/backend/global/scheduler/HashtagScheduler.java
@@ -1,0 +1,40 @@
+package com.example.backend.global.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.backend.content.hashtag.service.HashtagUsageCollector;
+import com.example.backend.entity.HashtagRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 해시태그 관련 스케줄러 업무를 실행
+ * @author kwak
+ * 2025/02/03
+ */
+@Component
+@RequiredArgsConstructor
+public class HashtagScheduler {
+
+	private final HashtagUsageCollector hashtagUsageCollector;
+	private final HashtagRepository hashtagRepository;
+
+	/**
+	 * 10분마다 한번씩 사용된 hashtag 들을 모아 최근사용시간을 수정하는 쿼리를 발생
+	 * @author kwak
+	 * @since 2025-02-03
+	 */
+	@Transactional
+	@Scheduled(fixedRate = 6000 * 10)
+	public void updateHashtagUsage() {
+		Set<Long> hashtagUsageData = hashtagUsageCollector.flushUsageStorage();
+		if (!hashtagUsageData.isEmpty()) {
+			hashtagRepository.bulkLastUsedAt(hashtagUsageData, LocalDateTime.now());
+		}
+	}
+}

--- a/backend/src/test/java/com/example/backend/content/hashtag/service/HashtagServiceTest.java
+++ b/backend/src/test/java/com/example/backend/content/hashtag/service/HashtagServiceTest.java
@@ -24,6 +24,9 @@ class HashtagServiceTest {
 	@InjectMocks
 	private HashtagService hashtagService;
 
+	@Mock
+	private HashtagUsageCollector collector;
+
 	@Test
 	@DisplayName("db에 존재하면 저장이 되지 않아야 함")
 	void createIfNotExists() {

--- a/backend/src/test/java/com/example/backend/content/hashtag/service/PostHashtagServiceTest.java
+++ b/backend/src/test/java/com/example/backend/content/hashtag/service/PostHashtagServiceTest.java
@@ -54,9 +54,8 @@ class PostHashtagServiceTest {
 		Set<String> contents = Set.of("고양이", "강아지");
 
 		List<PostHashtagEntity> postHashtagEntities = postHashtagService.create(post, contents);
-		assertThat(postHashtagEntities.size()).isEqualTo(2);
-		assertThat(postHashtagEntities.get(0).getHashtag().getContent()).isEqualTo("고양이");
-		assertThat(postHashtagEntities.get(1).getHashtag().getContent()).isEqualTo("강아지");
-
+		assertThat(postHashtagEntities)
+			.extracting(postHashtag -> postHashtag.getHashtag().getContent())
+			.containsExactlyInAnyOrder("고양이", "강아지");
 	}
 }

--- a/backend/src/test/java/com/example/backend/global/scheduler/HashtagSchedulerTest.java
+++ b/backend/src/test/java/com/example/backend/global/scheduler/HashtagSchedulerTest.java
@@ -1,6 +1,5 @@
 package com.example.backend.global.scheduler;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
@@ -13,14 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.example.backend.content.hashtag.scheduler.HashtagScheduler;
 import com.example.backend.content.hashtag.service.HashtagService;
 import com.example.backend.content.hashtag.service.HashtagUsageCollector;
 import com.example.backend.content.hashtag.service.PostHashtagService;
-import com.example.backend.entity.HashtagRepository;
-import com.example.backend.entity.PostHashtagRepository;
 
 /**
  * 각 비즈니스 로직 단위 테스트만 진행하고

--- a/backend/src/test/java/com/example/backend/global/scheduler/HashtagSchedulerTest.java
+++ b/backend/src/test/java/com/example/backend/global/scheduler/HashtagSchedulerTest.java
@@ -1,0 +1,100 @@
+package com.example.backend.global.scheduler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.backend.content.hashtag.service.HashtagService;
+import com.example.backend.content.hashtag.service.HashtagUsageCollector;
+import com.example.backend.content.hashtag.service.PostHashtagService;
+import com.example.backend.entity.HashtagRepository;
+import com.example.backend.entity.PostHashtagRepository;
+
+/**
+ * 각 비즈니스 로직 단위 테스트만 진행하고
+ * 스케줄러가 잘 작동하는지는 로컬에서 직접 확인
+ * @author kwak
+ * 2025-02-04
+ */
+
+@ExtendWith(MockitoExtension.class)
+class HashtagSchedulerTest {
+
+	@Mock
+	HashtagUsageCollector hashtagUsageCollector;
+	@Mock
+	PostHashtagService postHashtagService;
+	@Mock
+	HashtagService hashtagService;
+	@InjectMocks
+	HashtagScheduler hashtagScheduler;
+
+	@Test
+	@DisplayName("해시태그 사용 데이터가 비어있으면 아무것도 안함")
+	void dont_update_hashtagUsage_if_empty() {
+		// given
+		when(hashtagUsageCollector.flushUsageStorage()).thenReturn(Collections.emptySet());
+
+		// when
+		hashtagScheduler.updateHashtagUsage();
+
+		// then
+		verify(hashtagService, never()).bulkLastUsedAt(anySet(), any());
+
+	}
+
+	@Test
+	@DisplayName("updateHashtagUsage 정상 수행")
+	void update_hashtagUsage() {
+		// given
+		Set<Long> hashtagIds = Set.of(1L, 2L, 3L);
+		when(hashtagUsageCollector.flushUsageStorage()).thenReturn(hashtagIds);
+
+		// when
+		hashtagScheduler.updateHashtagUsage();
+
+		// then
+		verify(hashtagService).bulkLastUsedAt(eq(hashtagIds), any(LocalDateTime.class));
+	}
+
+	@Test
+	@DisplayName("오래된 해시태그 데이터가 비어있으면 아무것도 안함")
+	void dont_update_deleteOldHashtag_if_empty() {
+		// given
+		when(hashtagService.findOldHashtags()).thenReturn(Collections.emptyList());
+
+		// when
+		hashtagScheduler.deleteOldHashtag();
+
+		// then
+		verify(postHashtagService, never()).deleteByHashtagIds(anyList());
+		verify(hashtagService, never()).deleteOldHashtag(anyList());
+	}
+
+	@Test
+	@DisplayName("오래된 해시태그 삭제 정상 수행")
+	void deleteOldHashtag() {
+		// given
+		List<Long> oldHashtags = List.of(1L, 2L, 3L);
+		when(hashtagService.findOldHashtags()).thenReturn(oldHashtags);
+
+		// when
+		hashtagScheduler.deleteOldHashtag();
+
+		// then
+		verify(postHashtagService).deleteByHashtagIds(eq(oldHashtags));
+		verify(hashtagService).deleteOldHashtag(eq(oldHashtags));
+	}
+}


### PR DESCRIPTION
## 📌 과제 설명
~~최근 6달 동안 사용하지 않은 해시태그는 삭제처리를 하는 기능을 구현한다~~
최근 3달 동안 사용하지 않은 해시태그는 삭제처리를 하는 기능을 구현한다

## 👩‍💻 요구 사항과 구현 내용
- post 가 삭제되거나 post content 에서 hashtag 가 수정이 되면 hashtag 와의 연결만 해제한다 (posthashtag 삭제)
  - 연결만 나타내는 데이터라 soft delete 할 필요성을 느끼지 못해 hardDelete 진행
- ~~최근 사용한 날짜 필드를 추가한다~~
- hashtag가 사용될 때 마다(생성 혹은 조회) 해당 hashtag 를 기록한다
  - 10분에 한번씩 사용된 hashtag 데이터를 모아 한번에 수정
- 오래된 hashtag 를 모아 삭제
  - 사용한지 3개월 이상된 hashtag 를 스케줄러를 통해 일괄삭제처리
  - 매일 오전 6시에 진행 

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
close #12 
