### PR TITLE
Feature/hashtag 03 해시태그 수정 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/service/PostHashtagService.java
@@ -46,12 +46,36 @@ public class PostHashtagService {
 		postHashtagRepository.bulkDeleteByHashtagIds(oldHashtagIds);
 	}
 
-	/**
-	 * post 삭제시 연관된 postHashtag 를 삭제하는 기능
-	 * @author kwak
-	 * @since 2025-02-04
-	 */
-	public void deleteByPostId(Long postId) {
-		postHashtagRepository.deleteByPostId(postId);
+	public List<PostHashtagEntity> findPostHashtagByPostId(Long postId) {
+		return postHashtagRepository.findPostHashtagByPostId(postId);
+	}
+
+	public void updatePostHashtags(PostEntity post, Set<String> newHashtags) {
+		List<PostHashtagEntity> postHashtags = findPostHashtagByPostId(post.getId());
+
+		// 기존 post 의 hashtags 추출
+		Set<String> currentHashtags = postHashtags.stream().map(
+			ph -> ph.getHashtag().getContent()
+		).collect(Collectors.toSet());
+
+		// 새로운 해시태그들에 포함되지 않는 현재 해시태그는 삭제될 해시태그 컨텐츠로 추출
+		Set<String> deletedHashtagContents = currentHashtags.stream()
+			.filter(currentHashtag -> !newHashtags.contains(currentHashtag))
+			.collect(Collectors.toSet());
+
+		// 없어진 해시태그들이 있으면 연결관계를 삭제
+		if (!deletedHashtagContents.isEmpty()) {
+			postHashtagRepository.deleteByPostIdAndHashtagContent(post.getId(), deletedHashtagContents);
+		}
+
+		// 새로운 해시태그들 추출
+		Set<String> updatedHashtags = newHashtags.stream()
+			.filter(newHashtag -> !currentHashtags.contains(newHashtag))
+			.collect(Collectors.toSet());
+
+		// 새로운 해시태그들이 존재하면 저장
+		if (!updatedHashtags.isEmpty()) {
+			create(post, updatedHashtags);
+		}
 	}
 }

--- a/backend/src/main/java/com/example/backend/entity/HashtagRepository.java
+++ b/backend/src/main/java/com/example/backend/entity/HashtagRepository.java
@@ -33,14 +33,21 @@ public interface HashtagRepository extends JpaRepository<HashtagEntity, Long> {
 	 * @since 2025-02-03
 	 */
 	@Modifying(clearAutomatically = true)
-	@Query("DELETE FROM HashtagEntity h WHERE h.id IN :ids")
-	int bulkDeleteByIds(@Param("ids") List<Long> ids);
+	@Query("""
+		DELETE FROM HashtagEntity h
+		WHERE h.id IN :ids
+		""")
+	void bulkDeleteByIds(@Param("ids") List<Long> ids);
 
 	/**
 	 * 사용한지 3개월 이상 된 hashtag Id 조회
 	 * @author kwak
 	 * @since 2025-02-03
 	 */
-	@Query("SELECT h.id FROM HashtagEntity h WHERE h.lastUsedAt < :date")
+	@Query("""
+		SELECT h.id
+		FROM HashtagEntity h
+		WHERE h.lastUsedAt < :date
+		""")
 	List<Long> findOldHashtags(@Param("targetDate") LocalDateTime targetDate);
 }

--- a/backend/src/main/java/com/example/backend/entity/PostHashtagRepository.java
+++ b/backend/src/main/java/com/example/backend/entity/PostHashtagRepository.java
@@ -39,6 +39,7 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtagEntity, 
 	 * @author kwak
 	 * @since 2025-02-04
 	 */
+	@Modifying(clearAutomatically = true)
 	@Query("""
 		DELETE FROM PostHashtagEntity ph
 		WHERE ph.post.id = :postId
@@ -46,4 +47,16 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtagEntity, 
 		""")
 	void deleteByPostIdAndHashtagContent(
 		@Param("postId") Long postId, @Param("deletedHashtagContents") Set<String> deletedHashtagContents);
+
+	/**
+	 * 연결된 Post 사용할꺼면 추후에 개선 필요
+	 * @author kwak
+	 * @since 2025-02-04
+	 */
+	@Query("""
+		SELECT ph FROM PostHashtagEntity ph
+		JOIN FETCH ph.hashtag h
+		WHERE ph.post.id = :id
+		""")
+	List<PostHashtagEntity> findByPostId(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/example/backend/entity/PostHashtagRepository.java
+++ b/backend/src/main/java/com/example/backend/entity/PostHashtagRepository.java
@@ -23,6 +23,27 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtagEntity, 
 		""")
 	void bulkDeleteByHashtagIds(@Param("hashtagIds") List<Long> hashtagIds);
 
-	@Query("DELETE FROM PostHashtagEntity ph WHERE ph.post.id = :postId")
-	void deleteByPostId(@Param("postId") Long postId);
+	/**
+	 * @author kwak
+	 * @since 2025-02-04
+	 */
+	@Query("""
+		SELECT ph FROM PostHashtagEntity ph
+		JOIN FETCH ph.post p
+		JOIN FETCH ph.hashtag h
+		WHERE ph.post.id = :id
+		""")
+	List<PostHashtagEntity> findPostHashtagByPostId(@Param("id") Long postId);
+
+	/**
+	 * @author kwak
+	 * @since 2025-02-04
+	 */
+	@Query("""
+		DELETE FROM PostHashtagEntity ph
+		WHERE ph.post.id = :postId
+		AND ph.hashtag.content IN :deletedHashtagContents
+		""")
+	void deleteByPostIdAndHashtagContent(
+		@Param("postId") Long postId, @Param("deletedHashtagContents") Set<String> deletedHashtagContents);
 }

--- a/backend/src/test/java/com/example/backend/content/hashtag/service/PostHashtagServiceTest.java
+++ b/backend/src/test/java/com/example/backend/content/hashtag/service/PostHashtagServiceTest.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.backend.entity.HashtagEntity;
+import com.example.backend.entity.HashtagRepository;
 import com.example.backend.entity.MemberEntity;
 import com.example.backend.entity.MemberRepository;
 import com.example.backend.entity.PostEntity;
@@ -24,6 +26,8 @@ import com.example.backend.entity.PostRepository;
 @Transactional
 class PostHashtagServiceTest {
 
+	@Autowired
+	HashtagRepository hashtagRepository;
 	@Autowired
 	PostHashtagService postHashtagService;
 	@Autowired
@@ -39,23 +43,82 @@ class PostHashtagServiceTest {
 	@DisplayName("create 통합 테스트")
 	void create() {
 
-		MemberEntity member = memberRepository.save(MemberEntity.builder()
-			.username("testUser")
-			.email("testuser@example.com")
-			.password("password123")
-			.build());
-
-		PostEntity post = postRepository.save(
-			PostEntity.builder()
-				.content("#고양이 짱짱귀엽네요")
-				.member(member)
-				.build());
-
+		//given
+		MemberEntity member = getMemberEntity();
+		PostEntity post = getPostEntity(member);
 		Set<String> contents = Set.of("고양이", "강아지");
 
+		//when
 		List<PostHashtagEntity> postHashtagEntities = postHashtagService.create(post, contents);
+
+		//then
 		assertThat(postHashtagEntities)
 			.extracting(postHashtag -> postHashtag.getHashtag().getContent())
 			.containsExactlyInAnyOrder("고양이", "강아지");
 	}
+
+	@Test
+	@DisplayName("해시태그 수정 정상 수행 - 기존 해시태그 삭제 및 새로운 해시태그 추가")
+	void updatePostHashtags() {
+
+		//given
+		MemberEntity member = getMemberEntity();
+		PostEntity post = getPostEntity(member);
+
+		HashtagEntity cat = HashtagEntity.builder()
+			.content("고양이")
+			.build();
+
+		HashtagEntity dog = HashtagEntity.builder()
+			.content("강아지")
+			.build();
+
+		HashtagEntity pen = HashtagEntity.builder()
+			.content("펭귄")
+			.build();
+
+		HashtagEntity hashtag1 = hashtagRepository.save(cat);
+		HashtagEntity hashtag2 = hashtagRepository.save(dog);
+
+		PostHashtagEntity ph1 = PostHashtagEntity.builder()
+			.post(post)
+			.hashtag(hashtag1)
+			.build();
+
+		PostHashtagEntity ph2 = PostHashtagEntity.builder()
+			.post(post)
+			.hashtag(hashtag2)
+			.build();
+
+		postHashtagRepository.save(ph1);
+		postHashtagRepository.save(ph2);
+
+		Set<String> newHashtags = Set.of("강아지", "펭귄");
+
+		//when
+		postHashtagService.updatePostHashtags(post, newHashtags);
+
+		//then
+		List<PostHashtagEntity> postHashtags = postHashtagRepository.findByPostId(post.getId());
+		assertThat(postHashtags)
+			.extracting(ph -> ph.getHashtag().getContent())
+			.containsExactlyInAnyOrder("강아지", "펭귄");
+	}
+
+	private PostEntity getPostEntity(MemberEntity member) {
+		return postRepository.save(
+			PostEntity.builder()
+				.content("#고양이 짱짱귀엽네요")
+				.member(member)
+				.build());
+	}
+
+	private MemberEntity getMemberEntity() {
+		return memberRepository.save(MemberEntity.builder()
+			.username("testUser")
+			.email("testuser@example.com")
+			.password("password123")
+			.build());
+	}
+
 }

--- a/backend/src/test/java/com/example/backend/content/hashtag/service/PostHashtagServiceUnitTest.java
+++ b/backend/src/test/java/com/example/backend/content/hashtag/service/PostHashtagServiceUnitTest.java
@@ -1,0 +1,89 @@
+package com.example.backend.content.hashtag.service;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.backend.entity.HashtagEntity;
+import com.example.backend.entity.PostEntity;
+import com.example.backend.entity.PostHashtagEntity;
+import com.example.backend.entity.PostHashtagRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PostHashtagServiceUnitTest {
+	@Mock
+	private HashtagService hashtagService;
+
+	@Mock
+	private PostHashtagRepository postHashtagRepository;
+
+	@InjectMocks
+	private PostHashtagService postHashtagService;
+
+	@Test
+	@DisplayName("없어진 해시태그들이 없을때 아무 수행도 안해야 한다")
+	void not_execute_deleteByPostIdAndHashtagContent() {
+		// given
+		PostEntity post = mock(PostEntity.class);
+		when(post.getId()).thenReturn(1L);
+
+		Set<String> newHashtags = Set.of("hashtag1", "hashtag2");
+		List<PostHashtagEntity> currentPostHashtags = Arrays.asList(
+			createPostHashtagEntity("hashtag1"),
+			createPostHashtagEntity("hashtag2")
+		);
+
+		when(postHashtagRepository.findPostHashtagByPostId(1L))
+			.thenReturn(currentPostHashtags);
+
+		// when
+		postHashtagService.updatePostHashtags(post, newHashtags);
+
+		// then
+		verify(postHashtagRepository, never())
+			.deleteByPostIdAndHashtagContent(anyLong(), anySet());
+		verify(postHashtagRepository, never()).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("새로운 해시태그들이 없으면 아무 수행도 안해야 된다")
+	void not_execute_create() {
+		// given
+		PostEntity post = mock(PostEntity.class);
+		when(post.getId()).thenReturn(1L);
+
+		Set<String> newHashtags = Set.of("hashtag1");
+		List<PostHashtagEntity> currentPostHashtags = Arrays.asList(
+			createPostHashtagEntity("hashtag1")
+		);
+
+		when(postHashtagRepository.findPostHashtagByPostId(1L))
+			.thenReturn(currentPostHashtags);
+
+		// when
+		postHashtagService.updatePostHashtags(post, newHashtags);
+
+		// then
+		verify(hashtagService, never()).createIfNotExists(anyString());
+		verify(postHashtagRepository, never()).saveAll(anyList());
+	}
+
+	private PostHashtagEntity createPostHashtagEntity(String content) {
+		HashtagEntity hashtag = mock(HashtagEntity.class);
+		when(hashtag.getContent()).thenReturn(content);
+
+		PostHashtagEntity postHashtag = mock(PostHashtagEntity.class);
+		when(postHashtag.getHashtag()).thenReturn(hashtag);
+
+		return postHashtag;
+	}
+}


### PR DESCRIPTION
## 📌 과제 설명 
post content 에서 기존 해시태그가 수정 되었을 때 기능 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- content 에 해시태그 변경 사항이 있을 때 이를 반영한다. 
  - post 에서 content 가 수정되면 추출기를 통해 걸러진 새로운 hashtags 들을 가져온다
  - 기존 post 의 hashtag 를 추출한다
  - 새로운 해시태그들에 포함되지 않은 현재 해시태그는 연결관계(postHashtag)를 삭제 (ex #고양이가 content에서 사라졌다면 해당 연결관계 삭제)
  - 새로운 해시태그들을 추출하여 존재하면 저장, 연결관계 등록

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
close #19 
