### PR TITLE
Feature/search 01 검색 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/content/hashtag/exception/HashtagErrorCode.java
+++ b/backend/src/main/java/com/example/backend/content/hashtag/exception/HashtagErrorCode.java
@@ -11,12 +11,11 @@ import lombok.Getter;
 @Getter
 public enum HashtagErrorCode implements ErrorCodeIfs {
 
-	INVALID_HASHTAG_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태그 특수문자를 포함할 수 없습니다."),
-	EMPTY_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태그 내용이 없습니다."),
-	TOO_LONG_HASHTAG_CONTENT(HttpStatus.BAD_REQUEST, 400, "해시태그 길이가 10자를 초과합니다."),
-	NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 데이터를 찾을 수 없습니다.");
+	INVALID_HASHTAG_CONTENT(HttpStatus.BAD_REQUEST, "해시태그 특수문자를 포함할 수 없습니다."),
+	EMPTY_CONTENT(HttpStatus.BAD_REQUEST, "해시태그 내용이 없습니다."),
+	TOO_LONG_HASHTAG_CONTENT(HttpStatus.BAD_REQUEST, "해시태그 길이가 10자를 초과합니다."),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "해당 데이터를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
-	private final Integer code;
 	private final String description;
 }

--- a/backend/src/main/java/com/example/backend/content/search/controller/SearchController.java
+++ b/backend/src/main/java/com/example/backend/content/search/controller/SearchController.java
@@ -1,0 +1,46 @@
+package com.example.backend.content.search.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.backend.content.search.dto.SearchPostCursorResponse;
+import com.example.backend.content.search.service.SearchService;
+import com.example.backend.content.search.type.SearchType;
+import com.example.backend.global.rs.RsData;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * type 은 author 와 hashtag 두가지로 나눠서 검색 가능
+ * 처음에 lastPostId 는 null
+ * @author kwak
+ * 2025-02-06
+ */
+@RestController
+@RequestMapping("/api-v1/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+	private final SearchService searchService;
+
+	@ResponseStatus(HttpStatus.OK)
+	@GetMapping
+	public RsData<SearchPostCursorResponse> search(
+		@RequestParam @NotNull(message = "검색 타입은 필수입니다.") SearchType type,
+		@RequestParam @NotBlank(message = "검색어는 필수입니다.") String keyword,
+		@RequestParam(required = false) Long lastPostId,
+		@RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
+	) {
+		SearchPostCursorResponse response = searchService.search(type, keyword, lastPostId, size);
+		return RsData.success(response);
+	}
+}

--- a/backend/src/main/java/com/example/backend/content/search/dto/SearchPostCursorResponse.java
+++ b/backend/src/main/java/com/example/backend/content/search/dto/SearchPostCursorResponse.java
@@ -1,0 +1,27 @@
+package com.example.backend.content.search.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+/**
+ * SearchPostResponse 에 lastPostId 와 마지막 페이지의 여부가 포함
+ * @author kwak
+ * 2025-02-07
+ */
+@Builder
+public record SearchPostCursorResponse(
+	List<SearchPostResponse> searchPostResponses,
+	Long lastPostId,
+	boolean hasNext
+) {
+	public static SearchPostCursorResponse create(
+		List<SearchPostResponse> searchPostResponses, Long lastPostId, boolean hasNext) {
+
+		return SearchPostCursorResponse.builder()
+			.searchPostResponses(searchPostResponses)
+			.lastPostId(lastPostId)
+			.hasNext(hasNext)
+			.build();
+	}
+}

--- a/backend/src/main/java/com/example/backend/content/search/dto/SearchPostResponse.java
+++ b/backend/src/main/java/com/example/backend/content/search/dto/SearchPostResponse.java
@@ -1,0 +1,15 @@
+package com.example.backend.content.search.dto;
+
+import lombok.Builder;
+
+/**
+ * 검색 시 간단한 이미지 결과와 연결한 postId 를 반환하는 response
+ * @author kwak
+ * 2025-02-07
+ */
+@Builder
+public record SearchPostResponse(
+	Long postId,
+	String imageUrl
+) {
+}

--- a/backend/src/main/java/com/example/backend/content/search/dto/SearchPostResponse.java
+++ b/backend/src/main/java/com/example/backend/content/search/dto/SearchPostResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 /**
  * 검색 시 간단한 이미지 결과와 연결한 postId 를 반환하는 response
+ * 게시글의 첫번째 이미지만 받아서 반환
  * @author kwak
  * 2025-02-07
  */

--- a/backend/src/main/java/com/example/backend/content/search/exception/SearchErrorCode.java
+++ b/backend/src/main/java/com/example/backend/content/search/exception/SearchErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.backend.content.search.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.backend.global.error.ErrorCodeIfs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author kwak
+ * 2025-02-07
+ */
+@Getter
+@AllArgsConstructor
+public enum SearchErrorCode implements ErrorCodeIfs {
+
+	INVALID_SEARCH_TYPE(HttpStatus.BAD_REQUEST, "검색 타입이 잘못됐습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String description;
+
+}

--- a/backend/src/main/java/com/example/backend/content/search/exception/SearchException.java
+++ b/backend/src/main/java/com/example/backend/content/search/exception/SearchException.java
@@ -1,0 +1,43 @@
+package com.example.backend.content.search.exception;
+
+import com.example.backend.global.error.ErrorCodeIfs;
+import com.example.backend.global.exception.BackendExceptionIfs;
+
+import lombok.Getter;
+
+/**
+ * @author kwak
+ * 2025-02-07
+ */
+@Getter
+public class SearchException extends RuntimeException implements BackendExceptionIfs {
+
+	private final ErrorCodeIfs errorCodeIfs;
+	private final String errorDescription;
+
+	public SearchException(ErrorCodeIfs errorCodeIfs) {
+		super(errorCodeIfs.getDescription());
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorCodeIfs.getDescription();
+
+	}
+
+	public SearchException(ErrorCodeIfs errorCodeIfs, String errorDescription) {
+		super(errorCodeIfs.getDescription());
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorDescription;
+	}
+
+	public SearchException(ErrorCodeIfs errorCodeIfs, Throwable tx) {
+		super(tx);
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorCodeIfs.getDescription();
+	}
+
+	public SearchException(ErrorCodeIfs errorCodeIfs, Throwable tx, String errorDescription) {
+		super(tx);
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorDescription;
+	}
+
+}

--- a/backend/src/main/java/com/example/backend/content/search/implement/SearchFinder.java
+++ b/backend/src/main/java/com/example/backend/content/search/implement/SearchFinder.java
@@ -1,0 +1,106 @@
+package com.example.backend.content.search.implement;
+
+import static com.example.backend.entity.QHashtagEntity.*;
+import static com.example.backend.entity.QImageEntity.*;
+import static com.example.backend.entity.QMemberEntity.*;
+import static com.example.backend.entity.QPostEntity.*;
+import static com.example.backend.entity.QPostHashtagEntity.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.example.backend.content.search.dto.SearchPostCursorResponse;
+import com.example.backend.content.search.dto.SearchPostResponse;
+import com.example.backend.content.search.exception.SearchErrorCode;
+import com.example.backend.content.search.exception.SearchException;
+import com.example.backend.content.search.type.SearchType;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * type 에 따라 분기로 처리되는 동적쿼리
+ * @author kwak
+ * 2025-02-06
+ */
+@Component
+@RequiredArgsConstructor
+public class SearchFinder {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public SearchPostCursorResponse findByKeyword(SearchType type, String keyword, Long lastPostId, int size) {
+		if (type == SearchType.AUTHOR) {
+			return findByAuthor(keyword, lastPostId, size);
+		} else if (type == SearchType.HASHTAG) {
+			return findByHashtag(keyword, lastPostId, size);
+		}
+		throw new SearchException(SearchErrorCode.INVALID_SEARCH_TYPE);
+	}
+
+	private SearchPostCursorResponse findByAuthor(String keyword, Long lastPostId, int size) {
+		List<SearchPostResponse> searchPostResponses = jpaQueryFactory
+			.select(Projections.constructor(
+				SearchPostResponse.class,
+				imageEntity.imageUrl,
+				imageEntity.post.id
+			))
+			.from(imageEntity)
+			.join(imageEntity.post, postEntity)
+			.join(postEntity.member, memberEntity)
+			.where(
+				lastPostId != null ? imageEntity.post.id.lt(lastPostId) : null,
+				memberEntity.username.eq(keyword))
+			.orderBy(imageEntity.post.id.desc())
+			.limit(size + 1)
+			.fetch();
+
+		// 딱 size 만큼 데이터가 있을 때 처리를 위해 이와 같은 방식 사용
+		boolean hasNext = isHasNext(size, searchPostResponses);
+		// 검색 결과가 없으면 null,
+		Long newLastPostId = getNewLastPostId(searchPostResponses);
+
+		return SearchPostCursorResponse.create(searchPostResponses, newLastPostId, hasNext);
+	}
+
+	private SearchPostCursorResponse findByHashtag(String keyword, Long lastPostId, int size) {
+		List<SearchPostResponse> searchPostResponses = jpaQueryFactory
+			.select(Projections.constructor(
+				SearchPostResponse.class,
+				imageEntity.imageUrl,
+				imageEntity.post.id))
+			.from(imageEntity)
+			.join(imageEntity.post, postEntity)
+			.join(postHashtagEntity).on(postHashtagEntity.post.eq(postEntity))
+			.join(postHashtagEntity.hashtag, hashtagEntity)
+			.where(
+				lastPostId != null ? imageEntity.post.id.lt(lastPostId) : null,
+				hashtagEntity.content.containsIgnoreCase(keyword)
+			)
+			.orderBy(imageEntity.post.id.desc())
+			.limit(size + 1)
+			.fetch();
+
+		// 딱 size 만큼 데이터가 있을 때 처리를 위해 이와 같은 방식 사용
+		boolean hasNext = isHasNext(size, searchPostResponses);
+		// 검색 결과가 없으면 null,
+		Long newLastPostId = getNewLastPostId(searchPostResponses);
+
+		return SearchPostCursorResponse.create(searchPostResponses, newLastPostId, hasNext);
+	}
+
+	private Long getNewLastPostId(List<SearchPostResponse> searchPostResponses) {
+		return searchPostResponses.isEmpty() ? null : searchPostResponses.getLast().postId();
+	}
+
+	private boolean isHasNext(int size, List<SearchPostResponse> searchPostResponses) {
+		boolean hasNext = searchPostResponses.size() > size;
+		if (hasNext) {
+			searchPostResponses.removeLast();
+		}
+		return hasNext;
+	}
+
+}

--- a/backend/src/main/java/com/example/backend/content/search/service/SearchService.java
+++ b/backend/src/main/java/com/example/backend/content/search/service/SearchService.java
@@ -1,6 +1,7 @@
 package com.example.backend.content.search.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.backend.content.search.dto.SearchPostCursorResponse;
 import com.example.backend.content.search.implement.SearchFinder;
@@ -18,6 +19,7 @@ public class SearchService {
 
 	private final SearchFinder searchFinder;
 
+	@Transactional(readOnly = true)
 	public SearchPostCursorResponse search(SearchType type, String keyword, Long lastPostId, int size) {
 		return searchFinder.findByKeyword(type, keyword, lastPostId, size);
 	}

--- a/backend/src/main/java/com/example/backend/content/search/service/SearchService.java
+++ b/backend/src/main/java/com/example/backend/content/search/service/SearchService.java
@@ -1,0 +1,24 @@
+package com.example.backend.content.search.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.backend.content.search.dto.SearchPostCursorResponse;
+import com.example.backend.content.search.implement.SearchFinder;
+import com.example.backend.content.search.type.SearchType;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author kwak
+ * 2025-02-06
+ */
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+	private final SearchFinder searchFinder;
+
+	public SearchPostCursorResponse search(SearchType type, String keyword, Long lastPostId, int size) {
+		return searchFinder.findByKeyword(type, keyword, lastPostId, size);
+	}
+}

--- a/backend/src/main/java/com/example/backend/content/search/type/SearchType.java
+++ b/backend/src/main/java/com/example/backend/content/search/type/SearchType.java
@@ -1,0 +1,9 @@
+package com.example.backend.content.search.type;
+
+/**
+ * @author kwak
+ * 2025-02-06
+ */
+public enum SearchType {
+	AUTHOR, HASHTAG
+}

--- a/backend/src/main/java/com/example/backend/global/exceptionhandler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/backend/global/exceptionhandler/GlobalExceptionHandler.java
@@ -15,7 +15,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import com.example.backend.content.hashtag.exception.HashtagException;
 import com.example.backend.content.post.exception.PostException;
+import com.example.backend.content.search.exception.SearchException;
 import com.example.backend.global.error.GlobalErrorCode;
 import com.example.backend.global.exception.GlobalException;
 import com.example.backend.global.rs.ErrorRs;
@@ -156,5 +158,21 @@ public class GlobalExceptionHandler {
 				.code(HttpStatus.NOT_FOUND.value()) // 404 상태 코드
 				.message(ex.getMessage()) // 예외 메시지
 				.build()));
+	}
+
+	@ExceptionHandler(SearchException.class)
+	public ResponseEntity<RsData<?>> handleSearchException(SearchException ex, HttpServletRequest request) {
+		RsData<?> response = RsData.error(null, ex.getMessage());
+		return ResponseEntity
+			.status(ex.getErrorCodeIfs().getHttpStatus())
+			.body(response);
+	}
+
+	@ExceptionHandler(HashtagException.class)
+	public ResponseEntity<RsData<?>> handleHashtagException(HashtagException ex, HttpServletRequest request) {
+		RsData<?> response = RsData.error(null, ex.getMessage());
+		return ResponseEntity
+			.status(ex.getErrorCodeIfs().getHttpStatus())
+			.body(response);
 	}
 }

--- a/backend/src/test/java/com/example/backend/content/search/implement/SearchFinderTest.java
+++ b/backend/src/test/java/com/example/backend/content/search/implement/SearchFinderTest.java
@@ -1,0 +1,197 @@
+package com.example.backend.content.search.implement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+import com.example.backend.content.search.dto.SearchPostCursorResponse;
+import com.example.backend.content.search.type.SearchType;
+import com.example.backend.entity.HashtagEntity;
+import com.example.backend.entity.ImageEntity;
+import com.example.backend.entity.MemberEntity;
+import com.example.backend.entity.PostEntity;
+import com.example.backend.entity.PostHashtagEntity;
+import com.example.backend.global.config.QuerydslConfig;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * @author kwak
+ * 2025-02-07
+ */
+@DataJpaTest
+@Import({QuerydslConfig.class, SearchFinder.class})
+class SearchFinderTest {
+
+	@Autowired
+	EntityManager em;
+	@Autowired
+	JPAQueryFactory queryFactory;
+	@Autowired
+	SearchFinder searchFinder;
+
+	@BeforeEach
+	void setUp() {
+		searchFinder = new SearchFinder(queryFactory);
+
+		// member1 데이터 및 해시태그 생성
+		MemberEntity member1 = persistMember("testUser1", "a1@test.com");
+		HashtagEntity catTag = persistHashtag("고양이");
+
+		// member1의 첫 번째 post
+		PostEntity member1Post1 = persistPost(member1);
+		persistPostHashtag(member1Post1, catTag);
+		List.of("url1", "url2").forEach(url -> persistImage(member1Post1, url));
+
+		// member1의 두 번째 post
+		PostEntity member1Post2 = persistPost(member1);
+		persistPostHashtag(member1Post2, catTag);
+		List.of("url3", "url4").forEach(url -> persistImage(member1Post2, url));
+
+		// member2 데이터 및 해시태그 생성
+		MemberEntity member2 = persistMember("testUser2", "a2@test.com");
+		HashtagEntity dogTag = persistHashtag("강아지");
+
+		// member2의 첫 번째 post
+		PostEntity member2Post1 = persistPost(member2);
+		persistPostHashtag(member2Post1, dogTag);
+		List.of("url5", "url6").forEach(url -> persistImage(member2Post1, url));
+
+		// member2의 두 번째 post
+		PostEntity member2Post2 = persistPost(member2);
+		persistPostHashtag(member2Post2, dogTag);
+		List.of("url7", "url8").forEach(url -> persistImage(member2Post2, url));
+
+		em.flush();
+		em.clear();
+	}
+
+	private MemberEntity persistMember(String username, String email) {
+		MemberEntity member = MemberEntity.builder()
+			.username(username)
+			.email(email)
+			.password("1234")
+			.refreshToken(UUID.randomUUID().toString())
+			.build();
+		em.persist(member);
+		return member;
+	}
+
+	private PostEntity persistPost(MemberEntity member) {
+		PostEntity post = PostEntity.builder()
+			.member(member)
+			.build();
+		em.persist(post);
+		return post;
+	}
+
+	private void persistImage(PostEntity post, String imageUrl) {
+		ImageEntity image = ImageEntity.builder()
+			.post(post)
+			.imageUrl(imageUrl)
+			.build();
+		em.persist(image);
+	}
+
+	private HashtagEntity persistHashtag(String content) {
+		HashtagEntity hashtag = HashtagEntity.builder()
+			.content(content)
+			.build();
+		em.persist(hashtag);
+		return hashtag;
+	}
+
+	private void persistPostHashtag(PostEntity post, HashtagEntity hashtag) {
+		PostHashtagEntity postHashtag = PostHashtagEntity.builder()
+			.post(post)
+			.hashtag(hashtag)
+			.build();
+		em.persist(postHashtag);
+	}
+
+	@Test
+	@DisplayName("작성자 기반 검색 , member1의 post 2개중 최신꺼의 첫번째 이미지만 반환")
+	@DirtiesContext
+	void test1() {
+		// when
+		SearchPostCursorResponse response = searchFinder.findByKeyword(
+			SearchType.AUTHOR, "testUser1", null, 10);
+
+		// then
+		assertThat(response.searchPostResponses()).hasSize(2);
+		assertThat(response.searchPostResponses().get(0).imageUrl())
+			.isEqualTo("url3");
+	}
+
+	@Test
+	@DisplayName("작성자 기반 검색, 커서 기반 페이징 정상 작동")
+	@DirtiesContext
+	void test2() {
+		// given
+		SearchPostCursorResponse firstPage = searchFinder.findByKeyword(
+			SearchType.AUTHOR, "testUser1", null, 1
+		);
+
+		Long lastPostId = firstPage.lastPostId();
+
+		// when
+		SearchPostCursorResponse nextPage = searchFinder.findByKeyword(
+			SearchType.AUTHOR, "testUser1", lastPostId, 10
+		);
+
+		// then
+		assertThat(nextPage.searchPostResponses()).hasSize(1);  // 두 번째 포스트 하나만 있어야 함
+		assertThat(nextPage.searchPostResponses())
+			.allMatch(post -> post.postId() < lastPostId);  // ID가 lastPostId 보다 작아야 함
+		assertThat(nextPage.hasNext()).isFalse();  // 더 이상 데이터가 없어야 함
+		assertThat(lastPostId).isEqualTo(2); // memeber 1의 Post는 두개뿐이기 때문에 lastPostId 2 여야함
+	}
+
+	@Test
+	@DisplayName("해시태그 기반 검색, 해시태그 관련 post 중 최신꺼의 첫번째 이미지만 반환")
+	@DirtiesContext
+	void test3() {
+		// when
+		SearchPostCursorResponse response = searchFinder.findByKeyword(
+			SearchType.HASHTAG, "고양이", null, 10);
+
+		// then
+		assertThat(response.searchPostResponses()).hasSize(2);  // 고양이 태그 달린 포스트 2개
+		assertThat(response.searchPostResponses().get(0).imageUrl())
+			.isEqualTo("url3");  // 최신 포스트의 첫번째 이미지
+	}
+
+	@Test
+	@DisplayName("해시태그 기반 검색, 커서 기반 페이징 정상 작동")
+	@DirtiesContext
+	void test4() {
+		//given
+		SearchPostCursorResponse firstPage = searchFinder.findByKeyword(
+			SearchType.HASHTAG, "고양이", null, 1
+		);
+
+		Long lastPostId = firstPage.lastPostId();
+
+		// when
+		SearchPostCursorResponse nextPage = searchFinder.findByKeyword(
+			SearchType.HASHTAG, "고양이", lastPostId, 10
+		);
+
+		// then
+		assertThat(nextPage.searchPostResponses()).hasSize(1);  // 두 번째 포스트 하나만 있어야 함
+		assertThat(nextPage.searchPostResponses())
+			.allMatch(post -> post.postId() < lastPostId);  // ID가 lastPostId 보다 작아야 함
+		assertThat(nextPage.hasNext()).isFalse();  // 더 이상 데이터가 없어야 함
+		assertThat(lastPostId).isEqualTo(2); // 고양이태그의 포스트는 두개뿐이기 때문에 lastPostId 2 여야함
+	}
+}


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
작성자와 해시태그를 기반으로 post 를 검색할 수 있는 검색 기능을 구현한다
- 타입(AUTHOR/HASHTAG)에 따른 포스트 검색 및 커서 기반 페이징

💡 기능 요청
- 커서 페이징 형태로 구현
- API 를 요청하면 사용자에게 각 게시물의 사진 첫장이 썸네일로 보여져야함
- 타입(AUTHOR, HASHTAG) 에 따라 keyword 를 분기처리하여 검색
- 클라이언트는 lastPostId 와 hasNext 필드를 통해 페이징에 대한 정보를 얻을 수 있음
- 요청 시 파라미터로 type, keyword, lastPostId, size 를 받음 (size 는 기본 10 설정)
- 처음 요청 시 lastPostId 는 null
- 작성자는 정확히 일치해야 하고 해시태그는 대소문자구분x, 포함되어있으면 반환



## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
