### PR TITLE
Refactor/like sync

### DIFF
--- a/backend/src/main/java/com/example/backend/social/reaction/like/util/component/LikeCountSynchronizer.java
+++ b/backend/src/main/java/com/example/backend/social/reaction/like/util/component/LikeCountSynchronizer.java
@@ -1,17 +1,17 @@
 package com.example.backend.social.reaction.like.util.component;
 
+import static com.example.backend.entity.QCommentEntity.*;
 import static com.example.backend.entity.QLikeEntity.*;
 import static com.example.backend.entity.QPostEntity.*;
-import static com.example.backend.entity.QCommentEntity.*;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -32,138 +32,86 @@ public class LikeCountSynchronizer {
     @Transactional
     public void synchronizeLikeCounts() {
         log.info("========좋아요 동기화 시작========");
-        
         try {
             // Post 엔티티 likeCount 동기화
             int updatedPosts = synchronizePostLikeCounts();
-            
             // Comment 엔티티 likeCount 동기화
             int updatedComments = synchronizeCommentLikeCounts();
-            
-            log.info("좋아요 카운트 동기화 완료: 게시물 {}회, 댓글{}회",
+
+            log.info("좋아요 수 동기화 완료: 게시물 {}회, 댓글{}회",
                     updatedPosts, updatedComments);
         } catch (Exception e) {
-            log.error("좋아요 동기화 중 에러 발생: {}", e.getMessage(), e);
+            log.error("좋아요 수 동기화 중 에러 발생: {}", e.getMessage(), e);
         }
     }
 
     /**
-     * Post 엔티티의 likeCount를 동기화하는 메소드
-     * @return updatedCount(post)
+     * 포스트 엔티티의 좋아요 수를 서브 쿼리를 이용해 동기화합니다.
+     * 각 포스트마다 likeEntity 테이블에서 실제 좋아요 카운트를 계산한 후,
+     * 현재 저장된 값과 다르면 업데이트합니다.
+     *
+     * @return 업데이트된 포스트 건수
      */
     private int synchronizePostLikeCounts() {
-        int updatedCount = 0;
-        
-        // 각 포스트별 실제 좋아요 수를 조회
-        var postLikeCounts = queryFactory
-                .select(likeEntity.resourceId, likeEntity.count())
+        // 포스트마다 좋아요 수를 계산하는 서브 쿼리
+        NumberExpression<Long> likeCountSubQuery = Expressions.numberTemplate(
+            Long.class,
+            "({0})",
+            JPAExpressions.select(likeEntity.count())
                 .from(likeEntity)
                 .where(
-                        likeEntity.resourceType.eq("POST"),
-                        likeEntity.isLiked.isTrue()
+                    likeEntity.resourceId.eq(postEntity.id),
+                    likeEntity.resourceType.eq("POST"),
+                    likeEntity.isLiked.isTrue()
                 )
-                .groupBy(likeEntity.resourceId)
-                .fetch();
-        
-        // 좋아요가 있는 포스트들의 ID 목록
-        List<Long> postsWithLikes = postLikeCounts.stream()
-                .map(tuple -> tuple.get(0, Long.class))
-                .collect(Collectors.toList());
-        
-        // 1. 좋아요가 있지만 카운트가 불일치하는 포스트 업데이트
-        for (var postLikeCount : postLikeCounts) {
-            Long postId = postLikeCount.get(0, Long.class);
-            Long likeCount = postLikeCount.get(1, Long.class);
-            
-            long updated = queryFactory
-                    .update(postEntity)
-                    .set(postEntity.likeCount, likeCount)
-                    .where(
-                            postEntity.id.eq(postId),
-                            postEntity.likeCount.ne(likeCount),
-                            postEntity.isDeleted.isFalse()
-                    )
-                    .execute();
-            
-            updatedCount += updated;
-        }
-        
-        // 2. 좋아요가 0이어야 하지만 현재 0이 아닌 포스트만 선택적으로 업데이트
-        if (!postsWithLikes.isEmpty()) {
-            long zeroLikeUpdated = queryFactory
-                    .update(postEntity)
-                    .set(postEntity.likeCount, 0L)
-                    .where(
-                            postEntity.id.notIn(postsWithLikes),
-                            postEntity.likeCount.ne(0L),
-                            postEntity.isDeleted.isFalse()
-                    )
-                    .execute();
-            
-            updatedCount += zeroLikeUpdated;
-        }
-        
-        log.info("{}개의 게시글 좋아요 카운트 업데이트 완료", updatedCount);
-        return updatedCount;
+        );
+
+        // 삭제되지 않은 포스트 중, 서브 쿼리 결과와 현재 likeCount가 다른 포스트 업데이트
+        long updatedPosts = queryFactory
+            .update(postEntity)
+            .set(postEntity.likeCount, likeCountSubQuery)
+            .where(
+                postEntity.isDeleted.isFalse(),
+                likeCountSubQuery.ne(postEntity.likeCount)
+            )
+            .execute();
+
+        log.info("게시글 {}개 -> 좋아요 수 동기화 완료", updatedPosts);
+        return (int) updatedPosts;
     }
 
     /**
-     * Comment 엔티티의 likeCount를 동기화하는 메소드
-     * @return updatedCount(comment)
+     * 댓글 엔티티의 좋아요 수를 서브 쿼리를 이용해 동기화합니다.
+     * 각 댓글마다 likeEntity 테이블에서 실제 좋아요 카운트를 계산한 후,
+     * 현재 저장된 값과 다르면 업데이트합니다.
+     *
+     * @return 업데이트된 댓글 건수
      */
     private int synchronizeCommentLikeCounts() {
-        int updatedCount = 0;
-        
-        // 각 댓글별 실제 좋아요 수를 조회
-        var commentLikeCounts = queryFactory
-                .select(likeEntity.resourceId, likeEntity.count())
+        // 댓글마다 좋아요 수를 계산하는 서브 쿼리
+        NumberExpression<Long> likeCountSubQuery = Expressions.numberTemplate(
+            Long.class,
+            "({0})",
+            JPAExpressions.select(likeEntity.count())
                 .from(likeEntity)
                 .where(
-                        likeEntity.resourceType.eq("COMMENT"),
-                        likeEntity.isLiked.isTrue()
+                    likeEntity.resourceId.eq(commentEntity.id),
+                    likeEntity.resourceType.eq("COMMENT"),
+                    likeEntity.isLiked.isTrue()
                 )
-                .groupBy(likeEntity.resourceId)
-                .fetch();
-        
-        // 좋아요가 있는 댓글들의 ID 목록
-        List<Long> commentsWithLikes = commentLikeCounts.stream()
-                .map(tuple -> tuple.get(0, Long.class))
-                .collect(Collectors.toList());
-        
-        // 1. 좋아요가 있지만 카운트가 불일치하는 댓글 업데이트
-        for (var commentLikeCount : commentLikeCounts) {
-            Long commentId = commentLikeCount.get(0, Long.class);
-            Long likeCount = commentLikeCount.get(1, Long.class);
-            
-            long updated = queryFactory
-                    .update(commentEntity)
-                    .set(commentEntity.likeCount, likeCount)
-                    .where(
-                            commentEntity.id.eq(commentId),
-                            commentEntity.likeCount.ne(likeCount),
-                            commentEntity.isDeleted.isFalse()
-                    )
-                    .execute();
-            
-            updatedCount += updated;
-        }
-        
-        // 2. 좋아요가 0이어야 하지만 현재 0이 아닌 댓글만 선택적으로 업데이트
-        if (!commentsWithLikes.isEmpty()) {
-            long zeroLikeUpdated = queryFactory
-                    .update(commentEntity)
-                    .set(commentEntity.likeCount, 0L)
-                    .where(
-                            commentEntity.id.notIn(commentsWithLikes),
-                            commentEntity.likeCount.ne(0L),
-                            commentEntity.isDeleted.isFalse()
-                    )
-                    .execute();
-            
-            updatedCount += zeroLikeUpdated;
-        }
-        
-        log.info("{}개의 댓글 좋아요 카운트 업데이트 완료", updatedCount);
-        return updatedCount;
+        );
+
+        // 삭제되지 않은 댓글 중, 서브 쿼리 결과와 현재 likeCount가 다른 댓글 업데이트
+        long updatedComments = queryFactory
+            .update(commentEntity)
+            .set(commentEntity.likeCount, likeCountSubQuery)
+            .where(
+                commentEntity.isDeleted.isFalse(),
+                likeCountSubQuery.ne(commentEntity.likeCount)
+            )
+            .execute();
+
+        log.info("댓글/대댓글 {}개 -> 좋아요 수 동기화 완료", updatedComments);
+        return (int) updatedComments;
     }
 }

--- a/backend/src/main/java/com/example/backend/social/reaction/like/util/component/LikeCountSynchronizer.java
+++ b/backend/src/main/java/com/example/backend/social/reaction/like/util/component/LikeCountSynchronizer.java
@@ -1,0 +1,169 @@
+package com.example.backend.social.reaction.like.util.component;
+
+import static com.example.backend.entity.QLikeEntity.*;
+import static com.example.backend.entity.QPostEntity.*;
+import static com.example.backend.entity.QCommentEntity.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeCountSynchronizer {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 30초마다 Post 엔티티와 Comment 엔티티의 likeCount를 동기화
+     */
+    @Async
+    @Scheduled(fixedRate = 30000) // 30초마다 실행
+    @Transactional
+    public void synchronizeLikeCounts() {
+        log.info("========좋아요 동기화 시작========");
+        
+        try {
+            // Post 엔티티 likeCount 동기화
+            int updatedPosts = synchronizePostLikeCounts();
+            
+            // Comment 엔티티 likeCount 동기화
+            int updatedComments = synchronizeCommentLikeCounts();
+            
+            log.info("좋아요 카운트 동기화 완료: 게시물 {}회, 댓글{}회",
+                    updatedPosts, updatedComments);
+        } catch (Exception e) {
+            log.error("좋아요 동기화 중 에러 발생: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Post 엔티티의 likeCount를 동기화하는 메소드
+     * @return updatedCount(post)
+     */
+    private int synchronizePostLikeCounts() {
+        int updatedCount = 0;
+        
+        // 각 포스트별 실제 좋아요 수를 조회
+        var postLikeCounts = queryFactory
+                .select(likeEntity.resourceId, likeEntity.count())
+                .from(likeEntity)
+                .where(
+                        likeEntity.resourceType.eq("POST"),
+                        likeEntity.isLiked.isTrue()
+                )
+                .groupBy(likeEntity.resourceId)
+                .fetch();
+        
+        // 좋아요가 있는 포스트들의 ID 목록
+        List<Long> postsWithLikes = postLikeCounts.stream()
+                .map(tuple -> tuple.get(0, Long.class))
+                .collect(Collectors.toList());
+        
+        // 1. 좋아요가 있지만 카운트가 불일치하는 포스트 업데이트
+        for (var postLikeCount : postLikeCounts) {
+            Long postId = postLikeCount.get(0, Long.class);
+            Long likeCount = postLikeCount.get(1, Long.class);
+            
+            long updated = queryFactory
+                    .update(postEntity)
+                    .set(postEntity.likeCount, likeCount)
+                    .where(
+                            postEntity.id.eq(postId),
+                            postEntity.likeCount.ne(likeCount),
+                            postEntity.isDeleted.isFalse()
+                    )
+                    .execute();
+            
+            updatedCount += updated;
+        }
+        
+        // 2. 좋아요가 0이어야 하지만 현재 0이 아닌 포스트만 선택적으로 업데이트
+        if (!postsWithLikes.isEmpty()) {
+            long zeroLikeUpdated = queryFactory
+                    .update(postEntity)
+                    .set(postEntity.likeCount, 0L)
+                    .where(
+                            postEntity.id.notIn(postsWithLikes),
+                            postEntity.likeCount.ne(0L),
+                            postEntity.isDeleted.isFalse()
+                    )
+                    .execute();
+            
+            updatedCount += zeroLikeUpdated;
+        }
+        
+        log.info("{}개의 게시글 좋아요 카운트 업데이트 완료", updatedCount);
+        return updatedCount;
+    }
+
+    /**
+     * Comment 엔티티의 likeCount를 동기화하는 메소드
+     * @return updatedCount(comment)
+     */
+    private int synchronizeCommentLikeCounts() {
+        int updatedCount = 0;
+        
+        // 각 댓글별 실제 좋아요 수를 조회
+        var commentLikeCounts = queryFactory
+                .select(likeEntity.resourceId, likeEntity.count())
+                .from(likeEntity)
+                .where(
+                        likeEntity.resourceType.eq("COMMENT"),
+                        likeEntity.isLiked.isTrue()
+                )
+                .groupBy(likeEntity.resourceId)
+                .fetch();
+        
+        // 좋아요가 있는 댓글들의 ID 목록
+        List<Long> commentsWithLikes = commentLikeCounts.stream()
+                .map(tuple -> tuple.get(0, Long.class))
+                .collect(Collectors.toList());
+        
+        // 1. 좋아요가 있지만 카운트가 불일치하는 댓글 업데이트
+        for (var commentLikeCount : commentLikeCounts) {
+            Long commentId = commentLikeCount.get(0, Long.class);
+            Long likeCount = commentLikeCount.get(1, Long.class);
+            
+            long updated = queryFactory
+                    .update(commentEntity)
+                    .set(commentEntity.likeCount, likeCount)
+                    .where(
+                            commentEntity.id.eq(commentId),
+                            commentEntity.likeCount.ne(likeCount),
+                            commentEntity.isDeleted.isFalse()
+                    )
+                    .execute();
+            
+            updatedCount += updated;
+        }
+        
+        // 2. 좋아요가 0이어야 하지만 현재 0이 아닌 댓글만 선택적으로 업데이트
+        if (!commentsWithLikes.isEmpty()) {
+            long zeroLikeUpdated = queryFactory
+                    .update(commentEntity)
+                    .set(commentEntity.likeCount, 0L)
+                    .where(
+                            commentEntity.id.notIn(commentsWithLikes),
+                            commentEntity.likeCount.ne(0L),
+                            commentEntity.isDeleted.isFalse()
+                    )
+                    .execute();
+            
+            updatedCount += zeroLikeUpdated;
+        }
+        
+        log.info("{}개의 댓글 좋아요 카운트 업데이트 완료", updatedCount);
+        return updatedCount;
+    }
+}

--- a/frontend/src/utils/likeUtils.ts
+++ b/frontend/src/utils/likeUtils.ts
@@ -1,0 +1,158 @@
+// 스토리지 키 접두사 
+const LIKE_STORAGE_KEY = 'feed_likes';
+const BOOKMARK_STORAGE_KEY = 'feed_bookmarks';
+
+// 타임스탬프 포함 - 시간 기반 무효화를 위한 구조
+interface LikeStatus {
+  isLiked: boolean;
+  likeCount: number;
+  timestamp: number;
+}
+
+interface BookmarkStatus {
+  isBookmarked: boolean;
+  bookmarkId: number; 
+  timestamp: number;
+}
+
+// 좋아요 상태 저장
+export const saveLikeStatus = (feedId: number, isLiked: boolean, likeCount: number): void => {
+  try {
+    const status: LikeStatus = {
+      isLiked,
+      likeCount,
+      timestamp: Date.now()
+    };
+    localStorage.setItem(`${LIKE_STORAGE_KEY}_${feedId}`, JSON.stringify(status));
+  } catch (error) {
+    console.error('좋아요 상태 저장 중 오류:', error);
+  }
+};
+
+// 북마크 상태 저장
+export const saveBookmarkStatus = (feedId: number, isBookmarked: boolean, bookmarkId: number): void => {
+  try {
+    const status: BookmarkStatus = {
+      isBookmarked,
+      bookmarkId,
+      timestamp: Date.now()
+    };
+    localStorage.setItem(`${BOOKMARK_STORAGE_KEY}_${feedId}`, JSON.stringify(status));
+  } catch (error) {
+    console.error('북마크 상태 저장 중 오류:', error);
+  }
+};
+
+// 좋아요 상태 가져오기
+export const getLikeStatus = (feedId: number, serverLikeStatus: boolean, serverLikeCount: number): { isLiked: boolean, likeCount: number } => {
+  try {
+    const stored = localStorage.getItem(`${LIKE_STORAGE_KEY}_${feedId}`);
+    
+    if (!stored) {
+      return { isLiked: serverLikeStatus, likeCount: serverLikeCount };
+    }
+    
+    const parsedStatus: LikeStatus = JSON.parse(stored);
+    
+    // 30초 이상 지난 데이터는 서버 데이터 우선 사용 (시간 기반 무효화)
+    const isExpired = Date.now() - parsedStatus.timestamp > 30000; // 30초
+    
+    if (isExpired) {
+      return { isLiked: serverLikeStatus, likeCount: serverLikeCount };
+    }
+    
+    return { 
+      isLiked: parsedStatus.isLiked, 
+      likeCount: parsedStatus.likeCount 
+    };
+  } catch (error) {
+    console.error('좋아요 상태 불러오기 중 오류:', error);
+    return { isLiked: serverLikeStatus, likeCount: serverLikeCount };
+  }
+};
+
+// 북마크 상태 가져오기
+export const getBookmarkStatus = (feedId: number, serverBookmarkId: number): { isBookmarked: boolean, bookmarkId: number } => {
+  try {
+    const stored = localStorage.getItem(`${BOOKMARK_STORAGE_KEY}_${feedId}`);
+    
+    if (!stored) {
+      return { 
+        isBookmarked: serverBookmarkId !== -1, 
+        bookmarkId: serverBookmarkId 
+      };
+    }
+    
+    const parsedStatus: BookmarkStatus = JSON.parse(stored);
+    
+    // 30초 이상 지난 데이터는 서버 데이터 우선 사용
+    const isExpired = Date.now() - parsedStatus.timestamp > 30000; // 30초
+    
+    if (isExpired) {
+      return { 
+        isBookmarked: serverBookmarkId !== -1, 
+        bookmarkId: serverBookmarkId 
+      };
+    }
+    
+    return { 
+      isBookmarked: parsedStatus.isBookmarked, 
+      bookmarkId: parsedStatus.bookmarkId 
+    };
+  } catch (error) {
+    console.error('북마크 상태 불러오기 중 오류:', error);
+    return { 
+      isBookmarked: serverBookmarkId !== -1, 
+      bookmarkId: serverBookmarkId 
+    };
+  }
+};
+
+// 일괄 업데이트 및 동기화를 위한 함수
+export const syncLikeStatuses = (feeds: any[]): any[] => {
+  return feeds.map(feed => {
+    const { isLiked, likeCount } = getLikeStatus(
+      feed.postId, 
+      !!feed.likeFlag, 
+      feed.likeCount || 0
+    );
+    
+    const { isBookmarked, bookmarkId } = getBookmarkStatus(
+      feed.postId,
+      feed.bookmarkId
+    );
+    
+    return {
+      ...feed,
+      likeFlag: isLiked,
+      likeCount: likeCount,
+      bookmarkId: bookmarkId
+    };
+  });
+};
+
+// 좋아요 데이터 청소 (선택적)
+export const cleanupLikeData = (maxAge = 60 * 60 * 1000): void => { // 기본 1시간
+  try {
+    const now = Date.now();
+    
+    // localStorage에서 모든 키 가져오기
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      
+      if (key && (key.startsWith(LIKE_STORAGE_KEY) || key.startsWith(BOOKMARK_STORAGE_KEY))) {
+        const value = localStorage.getItem(key);
+        if (value) {
+          const data = JSON.parse(value);
+          
+          // 특정 시간보다 오래된 데이터 삭제
+          if (now - data.timestamp > maxAge) {
+            localStorage.removeItem(key);
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error('좋아요 데이터 정리 중 오류:', error);
+  }
+};


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
본인의 좋아요 관련 내용을 로컬 Storage에 우선 저장 및 사용
이로 인해 feed는 로컬 Storage의 내용을 우선적으로 확인
이로 인해 다음과 같은 사항 해결 -> DB에 좋아요 반영전 발생하는 좋아요 괴리

likeEntity에 따라 post,comment의 likeCount 동기화 쿼리 작성
서브쿼리를 사용하지 않고 작성한 초기 쿼리는 데이터가 늘어남에 따라 쿼리량이 기하급수적으로 증가
따라서 서브쿼리를 채용해 쿼리 최적화
